### PR TITLE
CSR: Mise à vide du champ "State or Province Name"

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -78,7 +78,7 @@ Pour éviter de faire transiter la clé privée dans un dossier non protégé, o
 
 ````
 Country Name (2 letter code) [AU]:FR
-State or Province Name (full name) [Some-State]:
+State or Province Name (full name) [Some-State]:""
 Locality Name (eg, city) []:Marseille
 Organization Name (eg, company) [Internet Widgits Pty Ltd]:Example Inc.
 Organizational Unit Name (eg, section) []:


### PR DESCRIPTION
Sans les "" ça vaut "Some-State".
J'ai mis à vide parce que de ce que je comprends, ça ne fait pas de sens de préciser ça pour la France.
Dans un état fédéral où les states/provinces on un certaine autonomie et ou c'est souvent précisé dans les adresses par contre oui.
